### PR TITLE
Permit overriding the distribution name in metamerge file

### DIFF
--- a/script/mbtiny
+++ b/script/mbtiny
@@ -44,7 +44,7 @@ This is the legacy meta file. This is mainly useful for bootstrapping on CPAN cl
 
 =back
 
-The information for these files is gathered from various sources. The distribution name is taken from the local directory name. The version, abstract and author are taken from the main module of the distribution. Prerequisites are mostly taken from cpanfile, except when injected explicitly (e.g. a configure dependency on L<Module::Build::Tiny|Module::Build::Tiny>). A C<metamerge.json> or C<metamerge.yml> file can be used to merge any additional meta information you want (including dependencies).
+The information for these files is gathered from various sources. The distribution name is taken from the local directory name or the C<name> field in a C<metamerge.json> or C<metamerge.yml> file. The version, abstract and author are taken from the main module of the distribution. Prerequisites are mostly taken from cpanfile, except when injected explicitly (e.g. a configure dependency on L<Module::Build::Tiny|Module::Build::Tiny>). A C<metamerge.json> or C<metamerge.yml> file can be used to merge any additional meta information you want (including dependencies).
 
 =head1 WORKFLOWS
 


### PR DESCRIPTION
I find some distribution names to be too long to comfortably use in as a
directory. This patch will use the distribution name specified in the
"name" field in metamerge.{json,yml} if it exists.
