### PR TITLE
require version 1.000009 of Module::Metadata

### DIFF
--- a/META.json
+++ b/META.json
@@ -37,7 +37,7 @@
             "Getopt::Long" : "2.36",
             "JSON::PP" : "0",
             "Module::CPANfile" : "0",
-            "Module::Metadata" : "0",
+            "Module::Metadata" : "1.000009",
             "Module::Runtime" : "0",
             "Parse::CPAN::Meta" : "0",
             "Software::LicenseUtils" : "0",

--- a/META.yml
+++ b/META.yml
@@ -7,7 +7,7 @@ build_requires:
 configure_requires:
   Module::Build::Tiny: '0.039'
 dynamic_config: 0
-generated_by: 'App::ModuleBuildTiny version 0.011, CPAN::Meta::Converter version 2.143240'
+generated_by: 'App::ModuleBuildTiny version 0.011, CPAN::Meta::Converter version 2.150001'
 license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
@@ -29,7 +29,7 @@ requires:
   Getopt::Long: '2.36'
   JSON::PP: '0'
   Module::CPANfile: '0'
-  Module::Metadata: '0'
+  Module::Metadata: '1.000009'
   Module::Runtime: '0'
   Parse::CPAN::Meta: '0'
   Software::LicenseUtils: '0'

--- a/cpanfile
+++ b/cpanfile
@@ -9,7 +9,7 @@ requires 'File::Temp';
 requires 'Getopt::Long', '2.36';
 requires 'JSON::PP';
 requires 'Module::CPANfile';
-requires 'Module::Metadata';
+requires 'Module::Metadata', '1.000009';
 requires 'Module::Runtime';
 requires 'Parse::CPAN::Meta';
 requires 'Software::LicenseUtils';


### PR DESCRIPTION
regenerate fails on a stock (well travis-stock anyway) 5.14 because the
version of Module::Metadata's (1.000004) doesn't have provides which was
added in 1.000008 and improved in 1.000009
