### PR TITLE
Misc fixups for warnings

### DIFF
--- a/lib/App/ModuleBuildTiny.pm
+++ b/lib/App/ModuleBuildTiny.pm
@@ -118,7 +118,16 @@ sub get_meta {
 		defined $abstract
 			or warn "Could not parse abstract from `=head1 NAME` in $filename";
 
-		my $authors = [ map { / \A \s* (.+?) \s* \z /x } grep { /\S/ } split /\n/, $data->pod('AUTHOR') ];
+		my $authors = do {
+			my $author_pod = $data->pod('AUTHOR');
+			defined $author_pod
+				? [ map { / \A \s* (.+?) \s* \z /x } grep { /\S/ } split /\n/, $author_pod ]
+				: []
+		};
+
+		@{$authors}
+			or warn "Could not parse any authors from `=head1 AUTHOR` in $filename";
+
 		my $version = $data->version($data->name) or die "Cannot parse \$VERSION from $filename";
 		my (@license_sections) = grep { /licen[cs]e|licensing|copyright|legal|authors?\b/i } $data->pod_inside;
 

--- a/lib/App/ModuleBuildTiny.pm
+++ b/lib/App/ModuleBuildTiny.pm
@@ -133,13 +133,14 @@ sub get_meta {
 
 		my $license;
 		for my $license_section (@license_sections) {
+			next unless defined ( my $license_pod = $data->pod($license_section) );
 			require Software::LicenseUtils;
-			my $content = "=head1 LICENSE\n" . $data->pod($license_section);
+			my $content = "=head1 LICENSE\n" . $license_pod;
 			my @guess = Software::LicenseUtils->guess_license_from_pod($content);
 			next if not @guess;
 			croak "Couldn't parse license from $license_section: @guess" if @guess != 1;
 			my $class = $guess[0];
-			my ($year) = $data->pod($license_section) =~ /.*? copyright .*? ([\d\-]+)/;
+			my ($year) = $license_pod =~ /.*? copyright .*? ([\d\-]+)/;
 			require Module::Runtime;
 			Module::Runtime::require_module($class);
 			$license = $class->new({holder => $authors, year => $year});

--- a/lib/App/ModuleBuildTiny.pm
+++ b/lib/App/ModuleBuildTiny.pm
@@ -138,14 +138,14 @@ sub get_meta {
 			my $content = "=head1 LICENSE\n" . $license_pod;
 			my @guess = Software::LicenseUtils->guess_license_from_pod($content);
 			next if not @guess;
-			croak "Couldn't parse license from $license_section: @guess" if @guess != 1;
+			croak "Couldn't parse license from $license_section in $filename: @guess" if @guess != 1;
 			my $class = $guess[0];
 			my ($year) = $license_pod =~ /.*? copyright .*? ([\d\-]+)/;
 			require Module::Runtime;
 			Module::Runtime::require_module($class);
 			$license = $class->new({holder => $authors, year => $year});
 		}
-		croak 'No license found' if not $license;
+		croak "No license found in $filename" if not $license;
 
 		my $prereqs = -f 'cpanfile' ? do { require Module::CPANfile; Module::CPANfile->load('cpanfile')->prereq_specs } : {};
 		$prereqs->{configure}{requires}{'Module::Build::Tiny'} //= mbt_version();

--- a/lib/App/ModuleBuildTiny.pm
+++ b/lib/App/ModuleBuildTiny.pm
@@ -107,7 +107,17 @@ sub get_meta {
 
 		require Module::Metadata;
 		my $data = Module::Metadata->new_from_file($filename, collect_pod => 1) or die "Couldn't analyse $filename: $!";
-		my ($abstract) = $data->pod('NAME') =~ / \A \s+ \S+ \s? - \s? (.+?) \s* \z /x;
+
+		my ($abstract) = do {
+			my $name_pod = $data->pod('NAME');
+			defined $name_pod
+				? $name_pod =~ / \A \s+ \S+ \s? - \s? (.+?) \s* \z /x
+				: undef;
+		};
+
+		defined $abstract
+			or warn "Could not parse abstract from `=head1 NAME` in $filename";
+
 		my $authors = [ map { / \A \s* (.+?) \s* \z /x } grep { /\S/ } split /\n/, $data->pod('AUTHOR') ];
 		my $version = $data->version($data->name) or die "Cannot parse \$VERSION from $filename";
 		my (@license_sections) = grep { /licen[cs]e|licensing|copyright|legal|authors?\b/i } $data->pod_inside;


### PR DESCRIPTION
A few cryptic warning messages I bumped into running `regenerate` on a dist that didn't have any POD yet.

These added warnings/warning enancements should make the path to fixing these problems slightly clearer.

`warn` used for now because showing the calling context from `bin/mbtiny`  doesn't actually make things better for anyone.

Now filing this req I realise I could probably use `//` for some of these because you're already min-perling 5.10 , but I've mentally forgotten that exists.
