### PR TITLE
Fix Module::Metadata version requirement

### DIFF
--- a/lib/App/ModuleBuildTiny/Dist.pm
+++ b/lib/App/ModuleBuildTiny/Dist.pm
@@ -16,7 +16,7 @@ use File::Spec::Functions qw/catfile catdir rel2abs/;
 use File::Slurper qw/write_text read_binary/;
 use ExtUtils::Manifest qw/manifind maniskip maniread/;
 use Module::Runtime 'require_module';
-use Module::Metadata '1.000037';
+use Module::Metadata 1.000037;
 
 use Pod::Escapes qw/e2char/;
 


### PR DESCRIPTION
Passing a quoted version (unfortunately) just passes the version to import, and Module::Metadata doesn't use Exporter so the Exporter workaround doesn't apply, so this ends up not checking the version of Module::Metadata.