### PR TITLE
Expand description of metafiles recognized by mbtiny with examples

### DIFF
--- a/script/mbtiny
+++ b/script/mbtiny
@@ -44,7 +44,53 @@ This is the legacy meta file. This is mainly useful for bootstrapping on CPAN cl
 
 =back
 
-The information for these files is gathered from various sources. The distribution name is taken from the local directory name. The version, abstract and author are taken from the main module of the distribution. Prerequisites are mostly taken from a L<cpanfile>, C<prereqs.json>, or C<prereqs.yml> (whichever is present), except when injected explicitly (e.g. a configure dependency on L<Module::Build::Tiny|Module::Build::Tiny>). A C<metamerge.json> or C<metamerge.yml> file can be used to merge any additional meta information you want (including dependencies).
+The information for these files is gathered from various sources.
+
+=over 4
+
+=item *
+
+The distribution name is taken from the local directory name.
+
+=item *
+
+The version, abstract and author are taken from the main module of the distribution. 
+
+=item *
+
+Prerequisites are mostly taken from a L<cpanfile>, C<prereqs.json>, or C<prereqs.yml> (whichever is present), except when injected explicitly (e.g. a configure dependency on L<Module::Build::Tiny|Module::Build::Tiny>).
+
+ # cpanfile
+ requires 'perl' => '5.012';
+ requires 'Path::Tiny';
+ recommends 'Term::ReadLine::Gnu';
+ on test => sub {
+   requires 'Test::More' => '0.88';
+ };
+
+ # prereqs.yml
+ runtime:
+   requires:
+     perl: '5.012'
+     Path::Tiny: 0
+   recommends:
+     Term::ReadLine::Gnu: 0
+ test:
+   requires:
+     Test::More: '0.88'
+
+=item *
+
+A C<metamerge.json> or C<metamerge.yml> file can be used to merge any additional meta information you want (including dependencies). It is assumed to be in L<meta-spec 2 format|https://metacpan.org/pod/CPAN::Meta::Spec> unless otherwise specified.
+
+ # metamerge.yml
+ resources:
+   bugtracker:
+     web: 'https://github.com/rjbs/Dist-Zilla/issues'
+   homepage: 'http://dzil.org/'
+   x_IRC: 'irc://irc.perl.org/#distzilla'
+
+=back
 
 =head1 WORKFLOWS
 


### PR DESCRIPTION
Split out the description of how information is gathered for better discovery, and provide examples particularly of the prereqs and metamerge formats.